### PR TITLE
optional config for required created/updatedat params

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Book.updateOrCreate({name: 'New name', id: 2}, {skipUpdatedAt: true}, function(e
 TESTING
 =============
 
+You'll need `jscs` and `jshint` globally installed to run the tests which can be installed with this command: `npm install -g jshint jscs`.  These tools help maintain style and error checking.
+
 Run the tests in `test.js`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ BOOT OPTIONS
 
 The attribute names `createdAt` and `updatedAt` are configurable.  To use different values for the default attribute names add the following parameters to the mixin options.
 
-In this example we change `createdAt` and `updatedAt` to `createdOn` and `updatedOn`, respectively.
+You can also configure whether `createdAt` and `updatedAt` are required or not. This can be useful when applying this mixin to existing data where the `required` constraint would fail by default.
+
+In this example we change `createdAt` and `updatedAt` to `createdOn` and `updatedOn`, respectively. We also change the default `required` to `false`.
 
 ```json
   {
@@ -86,7 +88,8 @@ In this example we change `createdAt` and `updatedAt` to `createdOn` and `update
     "mixins": {
       "TimeStamp" : {
         "createdAt" : "createdOn",
-        "updatedAt" : "updatedOn"
+        "updatedAt" : "updatedOn",
+        "required" : false
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function timestamps(Model, options) {
 
   var createdAt = options.createdAt || 'createdAt';
   var updatedAt = options.updatedAt || 'updatedAt';
-  var required = options.required == undefined ? true : options.required
+  var required = options.required === undefined ? true : options.required;
 
   debug('createdAt', createdAt, options.createdAt);
   debug('updatedAt', updatedAt, options.updatedAt);

--- a/index.js
+++ b/index.js
@@ -8,12 +8,13 @@ function timestamps(Model, options) {
 
   var createdAt = options.createdAt || 'createdAt';
   var updatedAt = options.updatedAt || 'updatedAt';
+  var required = options.required == undefined ? true : options.required
 
   debug('createdAt', createdAt, options.createdAt);
   debug('updatedAt', updatedAt, options.updatedAt);
 
-  Model.defineProperty(createdAt, { type: Date, required: true, defaultFn: 'now' });
-  Model.defineProperty(updatedAt, { type: Date, required: true });
+  Model.defineProperty(createdAt, { type: Date, required: required, defaultFn: 'now' });
+  Model.defineProperty(updatedAt, { type: Date, required: required });
 
   Model.observe('before save', function event(ctx, next) {
     debug('ctx.options', ctx.options);

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "loopback-ds-timestamp-mixin",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "A mixin to automatically generate created and updated Date attributes for loopback Models",
   "main": "index.js",
   "scripts": {
+    "pretest": "jscs index.js && jshint index.js",
     "test": "mocha --reporter spec test.js",
     "outdated": "npm outdated --depth=0"
   },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "loopback-ds-timestamp-mixin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A mixin to automatically generate created and updated Date attributes for loopback Models",
   "main": "index.js",
   "scripts": {
-    "pretest": "jscs index.js && jshint index.js",
     "test": "mocha --reporter spec test.js",
     "outdated": "npm outdated --depth=0"
   },

--- a/test.js
+++ b/test.js
@@ -189,6 +189,26 @@ describe('loopback datasource timestamps', function() {
       });
     });
 
+    it('should default required on createdAt and updatedAt ', function(done) {
+      Book = dataSource.createModel('Book',
+        { name: String, type: String },
+        { mixins: {  TimeStamp: true } }
+        );
+      assert.equal(Book.definition.properties.createdAt.required, true);
+      assert.equal(Book.definition.properties.updatedAt.required, true);
+      done();
+    });
+
+    it('should have optional createdAt and updatedAt', function(done) {
+      Book = dataSource.createModel('Book',
+        { name: String, type: String },
+        { mixins: {  TimeStamp: { required: false } } }
+        );
+      assert.equal(Book.definition.properties.createdAt.required, false);
+      assert.equal(Book.definition.properties.updatedAt.required, false);
+      done();
+    });
+    
   });
 
   describe('operation hook options', function() {


### PR DESCRIPTION
Coming from #5 and #6 via @jasonaden

I just did some quick fixes so I could pull this in.  I'll bump the npm module in a minute.
