### PR TITLE
create new mixinSources capable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-WARNING
-=============
-Mixins are actively being implemented in loopback.  See the [loopback-boot mixins issue](https://github.com/strongloop/loopback-boot/issues/79) for more information on loopback mixins.  This module works as expected but may change as loopback changes.
-
-
 [![NPM](https://nodei.co/npm/loopback-ds-timestamp-mixin.png?compact=true)](https://nodei.co/npm/loopback-ds-timestamp-mixin/)
 
 [![dependencies](https://img.shields.io/david/clarkbw/loopback-ds-timestamp-mixin.svg)]()
@@ -28,8 +23,34 @@ INSTALL
   npm install --save loopback-ds-timestamp-mixin
 ```
 
+MIXINSOURCES
+=============
+With [loopback-boot@v2.8.0](https://github.com/strongloop/loopback-boot/)  [mixinSources](https://github.com/strongloop/loopback-boot/pull/131) have been implemented in a way which allows for loading this mixin without changes to the `server.js` file previously required.
+
+Add the `mixins` property to your `server/model-config.json` like the following:
+
+```json
+{
+  "_meta": {
+    "sources": [
+      "loopback/common/models",
+      "loopback/server/models",
+      "../common/models",
+      "./models"
+    ],
+    "mixins": [
+      "loopback/common/mixins",
+      "../node_modules/loopback-ds-timestamp-mixin",
+      "../common/mixins"
+    ]
+  }
+}
+```
+
 SERVER.JS
 =============
+
+DEPRECATED: See MIXINSOURCES above for configuration. Use this method ONLY if you cannot upgrade to loopback-boot@v2.8.0.
 
 In your `server/server.js` file add the following line before the `boot(app, __dirname);` line.
 

--- a/index.js
+++ b/index.js
@@ -1,36 +1,5 @@
+var deprecate = require('util').deprecate;
 
-var debug = require('debug')('loopback-ds-timestamp-mixin');
-
-function timestamps(Model, options) {
-  'use strict';
-
-  debug('TimeStamp mixin for Model %s', Model.modelName);
-
-  var createdAt = options.createdAt || 'createdAt';
-  var updatedAt = options.updatedAt || 'updatedAt';
-  var required = options.required === undefined ? true : options.required;
-
-  debug('createdAt', createdAt, options.createdAt);
-  debug('updatedAt', updatedAt, options.updatedAt);
-
-  Model.defineProperty(createdAt, { type: Date, required: required, defaultFn: 'now' });
-  Model.defineProperty(updatedAt, { type: Date, required: required });
-
-  Model.observe('before save', function event(ctx, next) {
-    debug('ctx.options', ctx.options);
-    if (ctx.options && ctx.options.skipUpdatedAt) { return next(); }
-    if (ctx.instance) {
-      debug('%s.%s before save: %s', ctx.Model.modelName, updatedAt, ctx.instance.id);
-      ctx.instance[updatedAt] = new Date();
-    } else {
-      debug('%s.%s before update matching %j', ctx.Model.pluralModelName, updatedAt, ctx.where);
-      ctx.data[updatedAt] = new Date();
-    }
-    next();
-  });
-
-}
-
-module.exports = function mixin(app) {
-  app.loopback.modelBuilder.mixins.define('TimeStamp', timestamps);
-};
+module.exports = deprecate(function mixin(app) {
+  app.loopback.modelBuilder.mixins.define('TimeStamp', require('./time-stamp'));
+}, 'DEPRECATED: Use mixinSources, see https://github.com/clarkbw/loopback-ds-timestamp-mixin#mixinsources');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A mixin to automatically generate created and updated Date attributes for loopback Models",
   "main": "index.js",
   "scripts": {
-    "pretest": "jscs index.js && jshint index.js",
+    "pretest": "jscs *.js && jshint *.js",
     "test": "nyc tap ./test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "outdated": "npm outdated --depth=0"

--- a/time-stamp.js
+++ b/time-stamp.js
@@ -1,0 +1,31 @@
+var debug = require('debug')('loopback-ds-timestamp-mixin');
+
+module.exports = function timestamp(Model, options) {
+  'use strict';
+
+  debug('TimeStamp mixin for Model %s', Model.modelName);
+
+  var createdAt = options.createdAt || 'createdAt';
+  var updatedAt = options.updatedAt || 'updatedAt';
+  var required = options.required === undefined ? true : options.required;
+
+  debug('createdAt', createdAt, options.createdAt);
+  debug('updatedAt', updatedAt, options.updatedAt);
+
+  Model.defineProperty(createdAt, { type: Date, required: required, defaultFn: 'now' });
+  Model.defineProperty(updatedAt, { type: Date, required: required });
+
+  Model.observe('before save', function event(ctx, next) {
+    debug('ctx.options', ctx.options);
+    if (ctx.options && ctx.options.skipUpdatedAt) { return next(); }
+    if (ctx.instance) {
+      debug('%s.%s before save: %s', ctx.Model.modelName, updatedAt, ctx.instance.id);
+      ctx.instance[updatedAt] = new Date();
+    } else {
+      debug('%s.%s before update matching %j', ctx.Model.pluralModelName, updatedAt, ctx.where);
+      ctx.data[updatedAt] = new Date();
+    }
+    next();
+  });
+
+};


### PR DESCRIPTION
This moves us away from the need to add the require line to a `server.js` file, instead using the `mixinSources` work in the loopback-boot module.

I still need to update the tests for this so I'll be bumping the version to 3.0.0 while I finish the transition.  
