### PR TITLE
add breaking test for `upsert`

### DIFF
--- a/test.js
+++ b/test.js
@@ -64,7 +64,7 @@ test('loopback datasource timestamps', function(tap) {
         });
       });
     });
-    
+
     t.test('should not change on upsert', function(tt) {
       var createdAt;
       Book.destroyAll(function() {

--- a/test.js
+++ b/test.js
@@ -64,6 +64,21 @@ test('loopback datasource timestamps', function(tap) {
         });
       });
     });
+    
+    t.test('should not change on upsert', function(tt) {
+      var createdAt;
+      Book.destroyAll(function() {
+        Book.create({name:'book 1', type:'fiction'}, function(err, book) {
+          tt.error(err);
+          tt.ok(book.createdAt);
+          Book.upsert({id: book.id, name:'book inf'}, function(err, b) {
+            tt.error(err);
+            tt.equal(book.createdAt, b.createdAt);
+            tt.end();
+          });
+        });
+      });
+    });
 
     t.test('should not change with bulk updates', function(tt) {
       var createdAt;


### PR DESCRIPTION
There is a quirk in this mixin: if you `upsert` a model (i.e. you just know the id and properties, but you don't want to `find` it first) the createdAt-Timestamp is updated, too. This must not happen, of course.
I fear it's related to the lb-ds-juggler's implementation of default values.

Can you think of a solution besides querying for the model everytime?
