### PR TITLE
Possible fix for validateUpsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ In this example we change `createdAt` and `updatedAt` to `createdOn` and `update
       "TimeStamp" : {
         "createdAt" : "createdOn",
         "updatedAt" : "updatedOn",
-        "required" : false
+        "required" : false,
+        "disableAllValidateUpsert" : true
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-ds-timestamp-mixin",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A mixin to automatically generate created and updated Date attributes for loopback Models",
   "main": "index.js",
   "scripts": {

--- a/time-stamp.js
+++ b/time-stamp.js
@@ -4,7 +4,17 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
@@ -19,7 +29,11 @@ exports['default'] = function (Model) {
 
   debug('TimeStamp mixin for Model %s', Model.modelName);
 
-  options = _extends({ createdAt: 'createdAt', updatedAt: 'updatedAt', required: true, disableAllValidateUpsert: false }, options);
+  options = _extends({ 
+    createdAt: 'createdAt', 
+    updatedAt: 'updatedAt', 
+    required: true, 
+    disableAllValidateUpsert: false }, options);
 
   debug('options', options);
 
@@ -29,7 +43,7 @@ exports['default'] = function (Model) {
   } else {
   
     // Check base model
-    if (Model.settings.base != "PersistedModel") {
+    if (Model.settings.base != 'PersistedModel') {
       // Check for PersistedModel static method
       try {
         Model.exists({ id: null }, function (err, exists) {
@@ -38,7 +52,8 @@ exports['default'] = function (Model) {
       }
       catch (err) {
         if (Model.settings.validateUpsert && options.required) {
-          console.warn('TimeStamp mixin requires validateUpsert be false in models not based on PersistedModel, override with disableAllValidateUpsert. See @clarkbw/loopback-ds-timestamp-mixin#10');
+          console.warn('TimeStamp mixin requires validateUpsert be false in models not based on PersistedModel.' +
+            'Override with disableAllValidateUpsert. See @clarkbw/loopback-ds-timestamp-mixin#10');
         }
       }
     }

--- a/time-stamp.js
+++ b/time-stamp.js
@@ -29,10 +29,10 @@ exports['default'] = function (Model) {
 
   debug('TimeStamp mixin for Model %s', Model.modelName);
 
-  options = _extends({ 
-    createdAt: 'createdAt', 
-    updatedAt: 'updatedAt', 
-    required: true, 
+  options = _extends({
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+    required: true,
     disableAllValidateUpsert: false }, options);
 
   debug('options', options);
@@ -41,7 +41,7 @@ exports['default'] = function (Model) {
     console.warn('%s.settings.validateUpsert was overriden to false', Model.pluralModelName);
     Model.settings.validateUpsert = false;
   } else {
-  
+
     // Check base model
     if (Model.settings.base != 'PersistedModel') {
       // Check for PersistedModel static method
@@ -59,8 +59,12 @@ exports['default'] = function (Model) {
     }
   }
 
-  Model.defineProperty(options.createdAt, { type: Date, required: options.required, defaultFn: 'now' });
-  Model.defineProperty(options.updatedAt, { type: Date, required: options.required });
+  if (typeof options.createdAt !== 'undefined' && options.createdAt !== null) {
+    Model.defineProperty(options.createdAt, { type: Date, required: options.required, defaultFn: 'now' });
+  }
+  if (typeof options.updatedAt !== 'undefined' && options.updatedAt !== null) {
+    Model.defineProperty(options.updatedAt, { type: Date, required: options.required });
+  }
 
   Model.observe('before save', function (ctx, next) {
     debug('ctx.options', ctx.options);
@@ -69,22 +73,30 @@ exports['default'] = function (Model) {
     }
     if (ctx.instance) {
       debug('%s.%s before save: %s', ctx.Model.modelName, options.updatedAt, ctx.instance.id);
-      ctx.instance[options.updatedAt] = new Date();
+      if (typeof options.updatedAt !== 'undefined' && options.updatedAt !== null) {
+        ctx.instance[options.updatedAt] = new Date();
+      }
     } else {
       debug('%s.%s before update matching %j', ctx.Model.pluralModelName, options.updatedAt, ctx.where);
 
-      if (ctx.currentInstance && ctx.currentInstance[options.createdAt]) {
-        debug('currentInstance.%s timestamp reused', options.createdAt);
-        ctx.data[options.createdAt] = ctx.currentInstance[options.createdAt];
-      } else {
-        ctx.data[options.createdAt] = new Date();
+      if (typeof options.createdAt !== 'undefined' && options.createdAt !== null) {
+        if (ctx.currentInstance && ctx.currentInstance[options.createdAt]) {
+          debug('currentInstance.%s timestamp reused', options.createdAt);
+          ctx.data[options.createdAt] = ctx.currentInstance[options.createdAt];
+        } else {
+          ctx.data[options.createdAt] = new Date();
+        }
       }
 
-      ctx.data[options.updatedAt] = new Date();
+      if (typeof options.updatedAt !== 'undefined' && options.updatedAt !== null) {
+        ctx.data[options.updatedAt] = new Date();
+      }
     }
     next();
   });
+
 };
+
 
 module.exports = exports['default'];
 //# sourceMappingURL=time-stamp.js.map

--- a/time-stamp.js
+++ b/time-stamp.js
@@ -25,19 +25,22 @@ exports['default'] = function (Model) {
 
   if (options.disableAllValidateUpsert) {
     console.warn('%s.settings.validateUpsert was overriden to false', Model.pluralModelName);
-    Model.settings.validateUpsert = false;  
+    Model.settings.validateUpsert = false;
   } else {
   
-    // Check for PersistedModel static method
-    try {
-        Model.exists({id: null}, function (err, exists) {
-        // Continue normally
+    // Check base model
+    if (Model.settings.base != "PersistedModel") {
+      // Check for PersistedModel static method
+      try {
+        Model.exists({ id: null }, function (err, exists) {
+          // Continue normally
         });
-    }
-    catch(err) {
+      }
+      catch (err) {
         if (Model.settings.validateUpsert && options.required) {
-            console.warn('TimeStamp mixin requires validateUpsert be false in models not based on PersistedModel, override with disableAllValidateUpsert. See @clarkbw/loopback-ds-timestamp-mixin#10');
+          console.warn('TimeStamp mixin requires validateUpsert be false in models not based on PersistedModel, override with disableAllValidateUpsert. See @clarkbw/loopback-ds-timestamp-mixin#10');
         }
+      }
     }
   }
 
@@ -54,14 +57,14 @@ exports['default'] = function (Model) {
       ctx.instance[options.updatedAt] = new Date();
     } else {
       debug('%s.%s before update matching %j', ctx.Model.pluralModelName, options.updatedAt, ctx.where);
-      
+
       if (ctx.currentInstance && ctx.currentInstance[options.createdAt]) {
         debug('currentInstance.%s timestamp reused', options.createdAt);
         ctx.data[options.createdAt] = ctx.currentInstance[options.createdAt];
       } else {
         ctx.data[options.createdAt] = new Date();
       }
-      
+
       ctx.data[options.updatedAt] = new Date();
     }
     next();


### PR DESCRIPTION
Possible fix for #10 , #11
Maybe even #17 (someone can test?)
#12 will be solved once https://github.com/strongloop/loopback-datasource-juggler/pull/516 will be incorporated.

The solution I revised follow this:

On the init phase:
1. Check if there's a disableAllValidateUpsert override. in that case simply continue normally.
2. if no override, 1st check to see if the model is based off PersistedModel
3. if not, give the warning (modified to mention the disableAllValidateUpsert)
4. if yes, continue as normal

On the hook:
1. Try to use ctx.currentInstance (available in PersistedModel based models)
2. If exists, reuse the createdAt for the update.
3. If not exists, set createdAt to date()
