### PR TITLE
Only override and warn if necessary

### DIFF
--- a/es6/time-stamp.js
+++ b/es6/time-stamp.js
@@ -13,7 +13,7 @@ export default (Model, bootOptions = {}) => {
 
   debug('options', options);
 
-  if (!options.validateUpsert) {
+  if (!options.validateUpsert && Model.settings.validateUpsert) {
     Model.settings.validateUpsert = false;
     console.warn('%s.settings.validateUpsert was overriden to false', Model.pluralModelName);
   }


### PR DESCRIPTION
This give the user the ability to prevent the `console.warn` output `MyModel.settings.validateUpsert was overriden to false` by setting

``` json
  "options": {
    "validateUpsert": false
  },
  "mixins": {
    "TimeStamp": true
  },
```

in their `MyModel.json` definition.

`npm test` ouput before:
<img width="742" alt="screen shot 2016-06-13 at 11 36 11 pm" src="https://cloud.githubusercontent.com/assets/1121256/16006200/ce29aad4-31bf-11e6-960b-d3682c321838.png">

...and after:
<img width="978" alt="screen shot 2016-06-13 at 11 36 38 pm" src="https://cloud.githubusercontent.com/assets/1121256/16006222/df4bc4b4-31bf-11e6-89a2-e9486bb4e2a6.png">
